### PR TITLE
fixed: update broken njRAT link

### DIFF
--- a/6-Malware/1-Using-njRAT.md
+++ b/6-Malware/1-Using-njRAT.md
@@ -3,11 +3,10 @@ njRAT is a RAT with powerful data-stealing capabilities. In addition to loggin k
 
 RATs help an attacker to remotely access complete GUI, control victim's computer without his or her awareness and are capable of performing screening and camera capture, code execution, keylogging, file access, password sniffing, registry management, and so on. It infects victims via phishing attacks and drive by downloads and propagates through infected USB keys or networked drives. It can download and execute additional malware, execute shell commands, read and write registry keys, capture screenshots, log keystrokes, and spy on webcams.
 
-![njrat-banner](https://mrpirate.net/wp-content/uploads/2019/01/Download-NjRat-Cracked-696x297.png)
 
 The njRAT Trojan can be used to control Botnets (network of computers), allowing the attacker to update, uninstall, disconnect, restart, close the RAT, and rename its compaign ID. The attacker can further create and configure the malware to spread through USB drives with the help of the Command and Control server software.
 
-https://mrpirate.net/njrat/
+[njRAT Official](https://www.njrat.org/2024/03/NjRat07D.html)
 
 ### Objectives 
 * Create a server using njRAT.


### PR DESCRIPTION

* Replaced outdated njRAT reference with the current official website link
* Removed broken njRAT banner image that was no longer accessible
